### PR TITLE
Allow Tuple in julianame

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -95,6 +95,8 @@ end
 
 Base.@pure julianame(names::Tuple{}, serializationname::Int) = serializationname
 
+Base.@pure julianame(name::Tuple{Symbol, Symbol}, serializationname::Symbol) = julianame(tuple(name), serializationname)
+
 Base.@pure function serializationname(names::Tuple{Vararg{Tuple{Symbol, Symbol}}}, julianame::Symbol)
     for nm in names
         nm[1] === julianame && return nm[2]


### PR DESCRIPTION
I hope it is appropriate to open a pull request. I figured it was easier to show what I mean than creating an issue. I was trying to read a single variable from a JSON object and found that `JSON3.read` fails when there is only one variable in the `StructType.names(::Type{mytype})` function.

Here is an example:

```
using JSON3, StructTypes
using StructTypes: StructType, Mutable

json = """{"name":"Daniel", "S":1}"""

mutable struct test
    S
    test() = new()
end

StructType(::Type{test}) = Mutable()
StructTypes.names(::Type{test}) = (:S, :S)

JSON3.read(json, test)
```
```
julia> JSON3.read(json, test)
ERROR: MethodError: no method matching julianame(::Tuple{Symbol,Symbol}, ::Symbol)
Closest candidates are:
  julianame(::Tuple{Vararg{Tuple{Symbol,Symbol},N} where N}, ::Symbol) at /home/daniel/.julia/packages/StructTypes/CpLmq/src/StructTypes.jl:89

julia> StructTypes.names(::Type{test}) = tuple((:S, :S))

julia> JSON3.read(json, test)
test(1)

julia> StructTypes.names(::Type{test}) = tuple()

julia> JSON3.read(json, test)
test(1)
```

The latter works, as far as I can tell, when the name in the struct is equal to the name in the JSON object. This PR will allow the first version. Let me know if I should change anything. :)
