### PR TITLE
Introduce a new constructfrom generic function

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -824,7 +824,7 @@ end
 function constructfrom(::DictType, ::Type{T}, ::Type{K}, ::Type{V}, ::Union{Struct, Mutable}, obj) where {T, K, V}
     d = Dict{K, V}()
     foreachfield(ToDictClosure(d), obj)
-    return constructfrom(T, d)
+    return construct(T, d)
 end
 
 constructfrom(::Mutable, ::Type{T}, obj) where {T} =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -418,6 +418,29 @@ end
 
 end
 
+abstract type Vehicle end
+
+struct Car <: Vehicle
+    type::String
+    make::String
+    model::String
+    seatingCapacity::Int
+    topSpeed::Float64
+end
+
+struct Truck <: Vehicle
+    type::String
+    make::String
+    model::String
+    payloadCapacity::Float64
+end
+
+StructTypes.StructType(::Type{Vehicle}) = StructTypes.AbstractType()
+StructTypes.subtypes(::Type{Vehicle}) = (car=Car, truck=Truck)
+
+StructTypes.StructType(::Type{Car}) = StructTypes.Struct()
+StructTypes.StructType(::Type{Truck}) = StructTypes.Struct()
+
 @testset "makeobj" begin
     @testset "makeobj" begin
         cases = [
@@ -461,6 +484,10 @@ end
             @test output.a == 1
             @test output.b == 2.0
             @test output.c == "three"
+            dict = Dict(:type => "car", :make => "Mercedes-Benz", :model => "S500", :seatingCapacity => 5, :topSpeed => 250.1)
+            car = StructTypes.constructfrom(Vehicle, dict)
+            @test typeof(car) == Car
+            @test car.make == "Mercedes-Benz"
         end
         @testset "constructfrom!" begin
             input = Dict(:a => 1, :b => 2.0, :c => "three")
@@ -471,6 +498,9 @@ end
             @test x.a == 1
             @test x.b == 2.0
             @test x.c == "three"
+            @test StructTypes.constructfrom(Tuple{Int64, Float64, String}, [1, 2.0, "three"]) == (1, 2.0, "three")
+            @test StructTypes.constructfrom(NamedTuple{(:a, :b, :c), Tuple{Int64, Float64, String}}, input) == (a=1, b=2.0, c="three")
+            @test StructTypes.constructfrom(NamedTuple{(:a, :b, :c), Tuple{Int64, Float64, String}}, x) == (a=1, b=2.0, c="three")
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -441,6 +441,16 @@ StructTypes.subtypes(::Type{Vehicle}) = (car=Car, truck=Truck)
 StructTypes.StructType(::Type{Car}) = StructTypes.Struct()
 StructTypes.StructType(::Type{Truck}) = StructTypes.Struct()
 
+mutable struct C2
+    a::Int
+    b::Float64
+    c::String
+    C2() = new()
+    C2(a::Int, b::Float64, c::String) = new(a, b, c)
+end
+
+StructTypes.StructType(::Type{C2}) = StructTypes.Mutable()
+
 @testset "makeobj" begin
     @testset "makeobj" begin
         cases = [
@@ -477,10 +487,9 @@ StructTypes.StructType(::Type{Truck}) = StructTypes.Struct()
     end
     @testset "mutable structs" begin
         @testset "constructfrom" begin
-            StructTypes.StructType(::Type{C}) = StructTypes.Mutable()
             input = Dict(:a => 1, :b => 2.0, :c => "three")
-            output = StructTypes.constructfrom(C, input)
-            @test typeof(output) === C
+            output = StructTypes.constructfrom(C2, input)
+            @test typeof(output) === C2
             @test output.a == 1
             @test output.b == 2.0
             @test output.c == "three"
@@ -491,10 +500,10 @@ StructTypes.StructType(::Type{Truck}) = StructTypes.Struct()
         end
         @testset "constructfrom!" begin
             input = Dict(:a => 1, :b => 2.0, :c => "three")
-            x = C()
+            x = C2()
             output = StructTypes.constructfrom!(x, input)
             @test x === output
-            @test typeof(x) === C
+            @test typeof(x) === C2
             @test x.a == 1
             @test x.b == 2.0
             @test x.c == "three"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -416,60 +416,63 @@ end
     end
 end
 
+StructTypes.StructType(::Type{A}) = StructTypes.Struct()
+@test StructTypes.constructfrom(A, Dict(:x => 1)) == A(1)
+
 end
 
-@testset "makeobj" begin
-    @testset "makeobj" begin
-        cases = [
-            (Any,               String,            "foo"),
-            (AbstractString,    String,            "foo"),
-            (String,            String,            "foo"),
-            (SubString,         SubString{String}, "foo"),
-            (SubString{String}, SubString{String}, "foo"),
-            (Any,               Int,               1),
-            (Real,              Int,               1),
-            (Integer,           Int,               1),
-            (Int,               Int,               1),
-            (Any,               Vector{Int},       [1, 2, 3]),
-            (Vector,            Vector{Int},       [1, 2, 3]),
-            (Vector{Any},       Vector{Any},       [1, 2, 3]),
-            (Vector{Real},      Vector{Real},      [1, 2, 3]),
-            (Vector{Integer},   Vector{Integer},   [1, 2, 3]),
-            (Vector{Int},       Vector{Int},       [1, 2, 3]),
-            (Any,               Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
-            (AbstractDict,      Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
-            (Dict,              Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
-            (Dict{Any, Any},    Dict{Any, Any},    Dict(:a => 1, :b => 2)),
-            (Dict{Symbol, Any}, Dict{Symbol, Any}, Dict(:a => 1, :b => 2)),
-            (Dict{Any, Int},    Dict{Any, Int},    Dict(:a => 1, :b => 2)),
-            (Dict{Symbol, Int}, Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
-        ]
-        for case in cases
-            a = case[1]
-            b = case[2]
-            c = case[3]
-            @test typeof(StructTypes.makeobj(a, c)) === b
-            @test StructTypes.makeobj(a, c) == c
-        end
-    end
-    @testset "mutable structs" begin
-        @testset "makeobj" begin
-            input = Dict(:a => 1, :b => 2.0, :c => "three")
-            output = StructTypes.makeobj(C, input)
-            @test typeof(output) === C
-            @test output.a == 1
-            @test output.b == 2.0
-            @test output.c == "three"
-        end
-        @testset "makeobj!" begin
-            input = Dict(:a => 1, :b => 2.0, :c => "three")
-            x = C()
-            output = StructTypes.makeobj!(x, input)
-            @test x === output
-            @test typeof(x) === C
-            @test x.a == 1
-            @test x.b == 2.0
-            @test x.c == "three"
-        end
-    end
-end
+# @testset "makeobj" begin
+#     @testset "makeobj" begin
+#         cases = [
+#             (Any,               String,            "foo"),
+#             (AbstractString,    String,            "foo"),
+#             (String,            String,            "foo"),
+#             (SubString,         SubString{String}, "foo"),
+#             (SubString{String}, SubString{String}, "foo"),
+#             (Any,               Int,               1),
+#             (Real,              Int,               1),
+#             (Integer,           Int,               1),
+#             (Int,               Int,               1),
+#             (Any,               Vector{Int},       [1, 2, 3]),
+#             (Vector,            Vector{Int},       [1, 2, 3]),
+#             (Vector{Any},       Vector{Any},       [1, 2, 3]),
+#             (Vector{Real},      Vector{Real},      [1, 2, 3]),
+#             (Vector{Integer},   Vector{Integer},   [1, 2, 3]),
+#             (Vector{Int},       Vector{Int},       [1, 2, 3]),
+#             (Any,               Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
+#             (AbstractDict,      Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
+#             (Dict,              Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
+#             (Dict{Any, Any},    Dict{Any, Any},    Dict(:a => 1, :b => 2)),
+#             (Dict{Symbol, Any}, Dict{Symbol, Any}, Dict(:a => 1, :b => 2)),
+#             (Dict{Any, Int},    Dict{Any, Int},    Dict(:a => 1, :b => 2)),
+#             (Dict{Symbol, Int}, Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
+#         ]
+#         for case in cases
+#             a = case[1]
+#             b = case[2]
+#             c = case[3]
+#             @test typeof(StructTypes.makeobj(a, c)) === b
+#             @test StructTypes.makeobj(a, c) == c
+#         end
+#     end
+#     @testset "mutable structs" begin
+#         @testset "makeobj" begin
+#             input = Dict(:a => 1, :b => 2.0, :c => "three")
+#             output = StructTypes.makeobj(C, input)
+#             @test typeof(output) === C
+#             @test output.a == 1
+#             @test output.b == 2.0
+#             @test output.c == "three"
+#         end
+#         @testset "makeobj!" begin
+#             input = Dict(:a => 1, :b => 2.0, :c => "three")
+#             x = C()
+#             output = StructTypes.makeobj!(x, input)
+#             @test x === output
+#             @test typeof(x) === C
+#             @test x.a == 1
+#             @test x.b == 2.0
+#             @test x.c == "three"
+#         end
+#     end
+# end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -416,63 +416,61 @@ end
     end
 end
 
-StructTypes.StructType(::Type{A}) = StructTypes.Struct()
-@test StructTypes.constructfrom(A, Dict(:x => 1)) == A(1)
-
 end
 
-# @testset "makeobj" begin
-#     @testset "makeobj" begin
-#         cases = [
-#             (Any,               String,            "foo"),
-#             (AbstractString,    String,            "foo"),
-#             (String,            String,            "foo"),
-#             (SubString,         SubString{String}, "foo"),
-#             (SubString{String}, SubString{String}, "foo"),
-#             (Any,               Int,               1),
-#             (Real,              Int,               1),
-#             (Integer,           Int,               1),
-#             (Int,               Int,               1),
-#             (Any,               Vector{Int},       [1, 2, 3]),
-#             (Vector,            Vector{Int},       [1, 2, 3]),
-#             (Vector{Any},       Vector{Any},       [1, 2, 3]),
-#             (Vector{Real},      Vector{Real},      [1, 2, 3]),
-#             (Vector{Integer},   Vector{Integer},   [1, 2, 3]),
-#             (Vector{Int},       Vector{Int},       [1, 2, 3]),
-#             (Any,               Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
-#             (AbstractDict,      Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
-#             (Dict,              Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
-#             (Dict{Any, Any},    Dict{Any, Any},    Dict(:a => 1, :b => 2)),
-#             (Dict{Symbol, Any}, Dict{Symbol, Any}, Dict(:a => 1, :b => 2)),
-#             (Dict{Any, Int},    Dict{Any, Int},    Dict(:a => 1, :b => 2)),
-#             (Dict{Symbol, Int}, Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
-#         ]
-#         for case in cases
-#             a = case[1]
-#             b = case[2]
-#             c = case[3]
-#             @test typeof(StructTypes.makeobj(a, c)) === b
-#             @test StructTypes.makeobj(a, c) == c
-#         end
-#     end
-#     @testset "mutable structs" begin
-#         @testset "makeobj" begin
-#             input = Dict(:a => 1, :b => 2.0, :c => "three")
-#             output = StructTypes.makeobj(C, input)
-#             @test typeof(output) === C
-#             @test output.a == 1
-#             @test output.b == 2.0
-#             @test output.c == "three"
-#         end
-#         @testset "makeobj!" begin
-#             input = Dict(:a => 1, :b => 2.0, :c => "three")
-#             x = C()
-#             output = StructTypes.makeobj!(x, input)
-#             @test x === output
-#             @test typeof(x) === C
-#             @test x.a == 1
-#             @test x.b == 2.0
-#             @test x.c == "three"
-#         end
-#     end
-# end
+@testset "makeobj" begin
+    @testset "makeobj" begin
+        cases = [
+            (Any,               String,            "foo"),
+            (AbstractString,    String,            "foo"),
+            (String,            String,            "foo"),
+            (SubString,         SubString{String}, "foo"),
+            (SubString{String}, SubString{String}, "foo"),
+            (Any,               Int,               1),
+            (Real,              Int,               1),
+            (Integer,           Int,               1),
+            (Int,               Int,               1),
+            (Any,               Vector{Int},       [1, 2, 3]),
+            (Vector,            Vector{Any},       [1, 2, 3]),
+            (Vector{Any},       Vector{Any},       [1, 2, 3]),
+            (Vector{Real},      Vector{Real},      [1, 2, 3]),
+            (Vector{Integer},   Vector{Integer},   [1, 2, 3]),
+            (Vector{Int},       Vector{Int},       [1, 2, 3]),
+            (Any,               Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
+            (AbstractDict,      Dict{Any, Any}, Dict(:a => 1, :b => 2)),
+            (Dict,              Dict{Any, Any}, Dict(:a => 1, :b => 2)),
+            (Dict{Any, Any},    Dict{Any, Any},    Dict(:a => 1, :b => 2)),
+            (Dict{Symbol, Any}, Dict{Symbol, Any}, Dict(:a => 1, :b => 2)),
+            (Dict{Any, Int},    Dict{Any, Int},    Dict(:a => 1, :b => 2)),
+            (Dict{Symbol, Int}, Dict{Symbol, Int}, Dict(:a => 1, :b => 2)),
+        ]
+        for case in cases
+            a = case[1]
+            b = case[2]
+            c = case[3]
+            @test typeof(StructTypes.constructfrom(a, c)) == b
+            @test StructTypes.constructfrom(a, c) == c
+        end
+    end
+    @testset "mutable structs" begin
+        @testset "constructfrom" begin
+            StructTypes.StructType(::Type{C}) = StructTypes.Mutable()
+            input = Dict(:a => 1, :b => 2.0, :c => "three")
+            output = StructTypes.constructfrom(C, input)
+            @test typeof(output) === C
+            @test output.a == 1
+            @test output.b == 2.0
+            @test output.c == "three"
+        end
+        @testset "constructfrom!" begin
+            input = Dict(:a => 1, :b => 2.0, :c => "three")
+            x = C()
+            output = StructTypes.constructfrom!(x, input)
+            @test x === output
+            @test typeof(x) === C
+            @test x.a == 1
+            @test x.b == 2.0
+            @test x.c == "three"
+        end
+    end
+end


### PR DESCRIPTION
An alternative, more generic approach to constructing generic objects
from other objects that also respects defined `StructTypes.StructType`
properties of both source and target objects. The usage is pretty
simple, just `StructTypes.constructfrom(T, obj)`, so give the type `T`
you want to construct, and a compatible object `obj`. `constructfrom`
will call `StructType` on the target type `T` and then proceed to
construct it appropriately, whether building up an array, dict, or
constructing a struct or mutable struct.

This is an alternative approach to the `makeobj` approach that existed
briefly. `constructfrom` is more generic in that it supports all
`StructType` types, and utilizes the `foreachfield`, `construct`, and
`applyfield!` utility functions to ensure serialization/deserialization
names are respected, keyword args, etc.

TODO:
  * write a bunch of tests to ensure the implementation is sound, can
  probably repurpose the old `makeobj` tests as a start
  * support `AbstractType`; shouldn't be too hard, just need to read the
  dispatching field and recursively call `constructfrom`
  * documentation of `constructfrom`