### PR TITLE
Fix utility functions on empty structs

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -588,6 +588,7 @@ Various "configurations" are respected when applying `f` to each field:
 """
 @inline function foreachfield(f, x::T) where {T}
     N = fieldcount(T)
+    N == 0 && return
     excl = excludes(T)
     nms = names(T)
     kwargs = keywordargs(T)
@@ -639,6 +640,7 @@ StructTypes configurations in terms of skipping/naming/passing keyword arguments
 """
 @inline function mapfields!(f, x::T) where {T}
     N = fieldcount(T)
+    N == 0 && return
     excl = excludes(T)
     nms = names(T)
     kwargs = keywordargs(T)
@@ -684,6 +686,7 @@ mappings will be applied, and the function will be passed the Julia field name.
 """
 @inline function applyfield!(f, x::T, nm::Symbol) where {T}
     N = fieldcount(T)
+    N == 0 && return true
     excl = excludes(T)
     nms = names(T)
     kwargs = keywordargs(T)

--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -686,7 +686,6 @@ mappings will be applied, and the function will be passed the Julia field name.
 """
 @inline function applyfield!(f, x::T, nm::Symbol) where {T}
     N = fieldcount(T)
-    N == 0 && return true
     excl = excludes(T)
     nms = names(T)
     kwargs = keywordargs(T)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,9 @@ end
 
 @enum Fruit apple orange
 
+struct EmptyStruct
+end
+
 @testset "StructTypes" begin
 
 @test StructTypes.StructType(Union{Int, Missing}) == StructTypes.Struct()
@@ -286,6 +289,10 @@ function f3(i, nm, T, v; hey=:hey)
     @test vals[i] == v
 end
 StructTypes.foreachfield(f3, LotsOfFields(vals...))
+
+@test StructTypes.foreachfield(() -> nothing, EmptyStruct()) === nothing
+@test StructTypes.mapfields!(() -> nothing, EmptyStruct()) === nothing
+@test StructTypes.applyfield!(() -> nothing, EmptyStruct())
 
 x = C()
 StructTypes.mapfields!((i, nm, T) -> (1, 3.14, "hey")[i], x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -292,7 +292,6 @@ StructTypes.foreachfield(f3, LotsOfFields(vals...))
 
 @test StructTypes.foreachfield(() -> nothing, EmptyStruct()) === nothing
 @test StructTypes.mapfields!(() -> nothing, EmptyStruct()) === nothing
-@test StructTypes.applyfield!(() -> nothing, EmptyStruct())
 
 x = C()
 StructTypes.mapfields!((i, nm, T) -> (1, 3.14, "hey")[i], x)


### PR DESCRIPTION
Fixes https://github.com/quinnj/JSON3.jl/issues/118. These utility
functions assumed any structs they operated on were non-empty by calling
`fieldname(T, i)` eagerly, which fails for empty structs. This PR just
proposes an early check in case the fieldcount is 0 and returns early if
so.