### PR TITLE
Fix default construct definition

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -242,7 +242,7 @@ abstract type InterfaceType end
 Function that custom types can overload for their `T` to construct an instance, given `args...` and `kw...`.
 The default definition is `StructTypes.construct(T, args...; kw...) = T(args...; kw...)`.
 """
-function construct end
+construct(T, args...; kw...) = T(args...; kw...)
 
 """
     StructTypes.StructType(::Type{T}) = StructTypes.DictType()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,6 +113,8 @@ x = "499beb72-22ea-11ea-3366-55749430b981"
 @test StructTypes.subtypes(A) == NamedTuple()
 @test StructTypes.subtypes(A(1)) == NamedTuple()
 
+@test StructTypes.construct(Date, Date(2020)) == Date(2020)
+
 end
 
 struct B


### PR DESCRIPTION
Fixes #37. We even mention in the `StructTypes.construct` docs that this is the default defintion, even though it wasn't. Whoops.