### PR TITLE
Pass `nothing` for missing struct fields in `construct`

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -66,6 +66,9 @@ serialization/deserialization *must* occur in its defined field order exclusivel
 an order can be guaranteed, but care must be taken to ensure any serialization formats can properly guarantee the order
 (for example, the JSON specification doesn't explicitly require ordered fields for "objects", though most implementations
 have a way to support this).
+
+For `StructTypes.UnorderedStruct`, if a field is missing from the serialization, `nothing` should be passed to the `StructTypes.construct` method.
+
 For example, when deserializing a `Struct.OrderedStruct`, parsed input fields are passed directly, in input order to the `T` constructor, like `T(field1, field2, field3)`.
 This means that field names may be ignored when deserializing; fields are directly passed to `T` in the order they're encountered.
 

--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -594,7 +594,7 @@ Note that any `StructTypes.names` mappings are applied, as well as field-specifi
              x_17, x_18, x_19, x_20, x_21, x_22, x_23, x_24, x_25, x_26, x_27, x_28, x_29, x_30, x_31, x_32, vals...)
 end
 
-Base.@pure function symbolin(names::Union{Tuple{Vararg{Symbol}}, Bool}, name::Symbol)
+Base.@pure function symbolin(names::Union{Tuple{Vararg{Symbol}}, Bool}, name)
     names isa Bool && return names
     for nm in names
         nm === name && return true
@@ -857,13 +857,17 @@ end
     constructor = T <: Tuple ? tuple : T <: NamedTuple ? ((x...) -> T(tuple(x...))) : T
     # unroll first 32 fields
     Base.@nexprs 32 i -> begin
-        x_i = values[i]::fieldtype(T, i)
+        if isassigned(values, i)
+            x_i = values[i]::fieldtype(T, i)
+        else
+            x_i = nothing
+        end
         if N == i
             return Base.@ncall(i, constructor, x)
         end
     end
     return constructor(x_1, x_2, x_3, x_4, x_5, x_6, x_7, x_8, x_9, x_10, x_11, x_12, x_13, x_14, x_15, x_16,
-             x_17, x_18, x_19, x_20, x_21, x_22, x_23, x_24, x_25, x_26, x_27, x_28, x_29, x_30, x_31, x_32, values[33:N]...)
+             x_17, x_18, x_19, x_20, x_21, x_22, x_23, x_24, x_25, x_26, x_27, x_28, x_29, x_30, x_31, x_32, map(i->isassigned(values, i) ? values[i] : nothing, values[33:N])...)
 end
 
 @static if Base.VERSION < v"1.2"


### PR DESCRIPTION
This primarily affects `StructTypes.UnorderedStruct` routines that end
up calling `StructTypes.construct` with fields passed in a
`Vector{Any}`. Before `UnorderedStruct` was introduced,
`StructTypes.Struct` structs were passed whatever arguments found when
deserializing in order to the constructor. With the introduction of
`UnorderedStruct`, we now aim to allow implementations to pass fields in
the correct order, regardless of how they were serialized. This poses a
problem, however, for fields not present in the serialized data, as is
often the case for JSON. It's typical to "omit null" fields when
serializing, but then when deserializing, we had the awkward scenario of
how to treat those not-present fields for `UnorderedStruct`
constructors. The proposal here is to pass `nothing` for not-present
fields, which mirrors the common pattern of "omitting null"s when
serializing, we're just providing the JSON equivalent of `null`,
`nothing` for that field. This should simplify `StructTypes.Struct`
custom type constructor's lives since they can now know to expect the
same number of arguments any time their type is deserialized; some may
be `nothing` if they are not present when deserializing. Fixes
https://github.com/quinnj/JSON3.jl/issues/136.