### PR TITLE
Add StructType trait definition for Base.VersionNumber

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -402,6 +402,7 @@ StructType(::Type{<:Enum}) = StringType()
 StructType(::Type{<:AbstractChar}) = StringType()
 StructType(::Type{UUID}) = StringType()
 StructType(::Type{T}) where {T <: Dates.TimeType} = StringType()
+StructType(::Type{VersionNumber}) = StringType()
 
 function construct(::Type{Char}, str::String; kw...)
     if length(str) == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -115,6 +115,10 @@ x = "499beb72-22ea-11ea-3366-55749430b981"
 
 @test StructTypes.construct(Date, Date(2020)) == Date(2020)
 
+# https://github.com/quinnj/JSON3.jl/issues/139
+v = v"1.2.3"
+@test StructTypes.StructType(v) == StructTypes.StringType()
+
 end
 
 struct B


### PR DESCRIPTION
It already satisfies the `StringType` interface, so it's an easy
definition. Fixes one issue mentioned in
https://github.com/quinnj/JSON3.jl/issues/139.