### PR TITLE
Add ignoreextras feature

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -79,6 +79,7 @@ Support functions for `StructTypes.DataType`s:
 ```@docs
 StructTypes.names
 StructTypes.excludes
+StructTypes.ignoreextras
 StructTypes.omitempties
 StructTypes.keywordargs
 StructTypes.idproperty

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,10 @@ struct OmitEmp
     x::Union{Nothing, Int}
 end
 
+struct IgnoreExtras
+    x::Int
+end
+
 @testset "StructTypes" begin
 
 @test StructTypes.StructType(Union{Int, Missing}) == StructTypes.Struct()
@@ -145,6 +149,11 @@ StructTypes.foreachfield(OmitEmp(nothing)) do i, nm, T, val
     counter += 1
 end
 @test counter == 0
+
+# ignoreextras(T)
+@test_throws Exception StructTypes.applyfield(identity, IgnoreExtras, :x)
+StructTypes.ignoreextras(::Type{IgnoreExtras}) = true
+@test !StructTypes.applyfield(identity, IgnoreExtras, :x)
 
 end
 
@@ -373,7 +382,7 @@ StructTypes.mapfields!((i, nm, T) -> (1, 3.14, "hey")[i], x2)
 
 # NamedTuple
 @test StructTypes.construct((i, nm, T) -> (1, 3.14, "hey")[i], NamedTuple{(:a, :b, :c), Tuple{Int64, Float64, String}}) == (a=1, b=3.14, c="hey")
-  
+
 x3 = D(nothing, 3.14, "")
 @inline StructTypes.omitempties(::Type{D}) = true
 all_i = Int[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,9 @@ end
 @test StructTypes.omitempties(A) == ()
 @test StructTypes.omitempties(A(1)) == ()
 
+@test !StructTypes.ignoreextras(A)
+@test !StructTypes.ignoreextras(A())
+
 @test StructTypes.isempty([])
 @test StructTypes.isempty(Dict())
 @test StructTypes.isempty("")


### PR DESCRIPTION
This is kind of a stopgap for my "do stuff with extra keys" use case, since it's just a lot easier to implement. 

Interestingly, the documentation for `applyfield` already says "returns false when `nm` isn't a valid field on `x`", so maybe we should just do `hasfield(T, nm) || return false` right at the beginning? 