### PR TITLE
Fix applyfield when applied to non-existent fields

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -827,7 +827,7 @@ mappings will be applied, and the function will be passed the Julia field name.
     # unroll the first 32 field checks to avoid dynamic dispatch if possible
     Base.@nif(
         33,
-        i -> (i <= N && Base.fieldindex(T, nm) === i && !symbolin(excl, nm)),
+        i -> (i <= N && fieldname(T, i) === nm && !symbolin(excl, nm)),
         i -> begin
             FT_i = fieldtype(T, i)
             if haskey(kwargs, nm)
@@ -839,7 +839,7 @@ mappings will be applied, and the function will be passed the Julia field name.
         end,
         i -> begin
             for j in 33:N
-                (Base.fieldindex(T, nm) === j && !symbolin(excl, nm)) || continue
+                (fieldname(T, j) === nm && !symbolin(excl, nm)) || continue
                 FT_j = fieldtype(T, j)
                 if haskey(kwargs, nm)
                     y_j = f(j, nm, FT_j; kwargs[nm]...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -370,7 +370,7 @@ StructTypes.mapfields!((i, nm, T) -> (1, 3.14, "hey")[i], x2)
 
 # NamedTuple
 @test StructTypes.construct((i, nm, T) -> (1, 3.14, "hey")[i], NamedTuple{(:a, :b, :c), Tuple{Int64, Float64, String}}) == (a=1, b=3.14, c="hey")
-  
+
 x3 = D(nothing, 3.14, "")
 @inline StructTypes.omitempties(::Type{D}) = true
 all_i = Int[]
@@ -437,6 +437,8 @@ end
 CNT = Ref(0)
 StructTypes.foreachfield((args...) -> CNT[] += 1, EmptyStruct)
 @test CNT[] == 0
+
+@test !StructTypes.applyfield((x...) -> 10, A, :y)
 
 @testset "StructTypes.constructfrom(T, ::Vector{Any})" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -438,7 +438,7 @@ CNT = Ref(0)
 StructTypes.foreachfield((args...) -> CNT[] += 1, EmptyStruct)
 @test CNT[] == 0
 
-@test !StructTypes.applyfield((x...) -> 10, A, :y)
+@test !StructTypes.applyfield((x...) -> 10, A, :z)
 
 @testset "StructTypes.constructfrom(T, ::Vector{Any})" begin
 


### PR DESCRIPTION
`applyfield` was inconsistent with `applyfield!` in that it threw an
error on non-existent fields rather than return `false`, which the
docuementation _said_ it did. This fixes `applyfield` to ignore
non-existent fieldnames and return `false`. Alternative fix to adding
teh `ignoreextras` function proposed in #52.