### PR TITLE
RFC: Add macros for setting StructType

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -2,6 +2,63 @@ module StructTypes
 
 using UUIDs, Dates
 
+for struct_type in (:Struct, :Mutable, :CustomStruct, :OrderedStruct, :AbstractType, :DictType, :ArrayType, :StringType, :NumberType, :BoolType, :NullType)
+    @eval begin
+        @doc """
+            @$($struct_type)(expr::Expr)
+            @$($struct_type)(expr::Symbol)
+        
+        If `expr` is a struct definition, sets the `StructType` of the defined struct to
+        $($struct_type)(). If `expr` is the name of a `Type`, sets the `StructType` of that
+        type to $($struct_type)().
+
+        # Examples
+        ```julia
+        @$($struct_type) MyStruct
+        ```
+        is equivalent to
+        ```julia
+        StructTypes.StructType(::Type{MyStruct}) = StructType.Struct()
+        ```
+        and 
+        ```julia
+        @$($struct_type) struct MyStruct
+            val::Int
+        end
+        ```
+        is equivalent to
+        ```julia
+        struct MyStruct
+            val::Int
+        end
+        StructTypes.StructType(::Type{MyStruct}) = StructType.Struct()
+        ```
+        """ macro $struct_type(expr)
+            return macro_constructor(expr, $struct_type)
+        end
+    end
+end
+
+function macro_constructor(expr::Expr, structtype)
+    if expr.head == :struct
+        return esc(quote
+            $expr
+            StructTypes.StructType(::Type{$(expr.args[2])}) = $structtype()
+        end)
+    else
+        return :(throw(ArgumentError("Macro constructors can only be used with a struct definition or a Type")))
+    end
+end
+function macro_constructor(expr::Symbol, structtype)
+    return esc(quote
+        if $(expr) isa Type
+            StructTypes.StructType(::Type{$(expr)}) = $structtype()
+        else
+            throw(ArgumentError("Macro constructors can only be used with a struct definition or a Type"))
+        end
+    end)
+end
+
 "Abstract super type of various `StructType`s; see `StructTypes.DataType`, `StructTypes.CustomType`, `StructTypes.InterfaceType`, and `StructTypes.AbstractType` for more specific kinds of `StructType`s"
 abstract type StructType end
 

--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -2,8 +2,6 @@ module StructTypes
 
 using UUIDs, Dates
 
-include("macros.jl")
-
 "Abstract super type of various `StructType`s; see `StructTypes.DataType`, `StructTypes.CustomType`, `StructTypes.InterfaceType`, and `StructTypes.AbstractType` for more specific kinds of `StructType`s"
 abstract type StructType end
 
@@ -1067,5 +1065,7 @@ function constructfrom(::AbstractType, ::Type{T}, obj::S) where {T, S}
     TT = types[Symbol(StructType(S) == DictType() ? obj[skey] : getfield(obj, skey))]
     return constructfrom(TT, obj)
 end
+
+include("macros.jl")
 
 end # module

--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -2,62 +2,7 @@ module StructTypes
 
 using UUIDs, Dates
 
-for struct_type in (:Struct, :Mutable, :CustomStruct, :OrderedStruct, :AbstractType, :DictType, :ArrayType, :StringType, :NumberType, :BoolType, :NullType)
-    @eval begin
-        @doc """
-            @$($struct_type)(expr::Expr)
-            @$($struct_type)(expr::Symbol)
-        
-        If `expr` is a struct definition, sets the `StructType` of the defined struct to
-        $($struct_type)(). If `expr` is the name of a `Type`, sets the `StructType` of that
-        type to $($struct_type)().
-
-        # Examples
-        ```julia
-        @$($struct_type) MyStruct
-        ```
-        is equivalent to
-        ```julia
-        StructTypes.StructType(::Type{MyStruct}) = StructType.Struct()
-        ```
-        and 
-        ```julia
-        @$($struct_type) struct MyStruct
-            val::Int
-        end
-        ```
-        is equivalent to
-        ```julia
-        struct MyStruct
-            val::Int
-        end
-        StructTypes.StructType(::Type{MyStruct}) = StructType.Struct()
-        ```
-        """ macro $struct_type(expr)
-            return macro_constructor(expr, $struct_type)
-        end
-    end
-end
-
-function macro_constructor(expr::Expr, structtype)
-    if expr.head == :struct
-        return esc(quote
-            $expr
-            StructTypes.StructType(::Type{$(expr.args[2])}) = $structtype()
-        end)
-    else
-        return :(throw(ArgumentError("Macro constructors can only be used with a struct definition or a Type")))
-    end
-end
-function macro_constructor(expr::Symbol, structtype)
-    return esc(quote
-        if $(expr) isa Type
-            StructTypes.StructType(::Type{$(expr)}) = $structtype()
-        else
-            throw(ArgumentError("Macro constructors can only be used with a struct definition or a Type"))
-        end
-    end)
-end
+include("macros.jl")
 
 "Abstract super type of various `StructType`s; see `StructTypes.DataType`, `StructTypes.CustomType`, `StructTypes.InterfaceType`, and `StructTypes.AbstractType` for more specific kinds of `StructType`s"
 abstract type StructType end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,16 +1,18 @@
+isolate_name(name) = split(string(name), '.')[end]
+
 for struct_type in (:Struct, :Mutable, :CustomStruct, :OrderedStruct, :AbstractType, :DictType, :ArrayType, :StringType, :NumberType, :BoolType, :NullType)
     @eval begin
-        @doc """
-            @$($struct_type)(expr::Expr)
-            @$($struct_type)(expr::Symbol)
+        """
+            @$(isolate_name($struct_type))(expr::Expr)
+            @$(isolate_name($struct_type))(expr::Symbol)
         
         If `expr` is a struct definition, sets the `StructType` of the defined struct to
-        $($struct_type)(). If `expr` is the name of a `Type`, sets the `StructType` of that
-        type to $($struct_type)().
+        `$(isolate_name($struct_type))()`. If `expr` is the name of a `Type`, sets the `StructType` of that
+        type to `$(isolate_name($struct_type))()`.
 
         # Examples
         ```julia
-        @$($struct_type) MyStruct
+        @$(isolate_name($struct_type)) MyStruct
         ```
         is equivalent to
         ```julia
@@ -18,7 +20,7 @@ for struct_type in (:Struct, :Mutable, :CustomStruct, :OrderedStruct, :AbstractT
         ```
         and 
         ```julia
-        @$($struct_type) struct MyStruct
+        @$(isolate_name($struct_type)) struct MyStruct
             val::Int
         end
         ```
@@ -42,7 +44,7 @@ function macro_constructor(expr::Expr, structtype)
             StructTypes.StructType(::Type{$(expr.args[2])}) = $structtype()
         end)
     else
-        return :(throw(ArgumentError("Macro constructors can only be used with a struct definition or a Type")))
+        return :(throw(ArgumentError("StructType macros can only be used with a struct definition or a Type")))
     end
 end
 function macro_constructor(expr::Symbol, structtype)
@@ -50,7 +52,7 @@ function macro_constructor(expr::Symbol, structtype)
         if $(expr) isa Type
             StructTypes.StructType(::Type{$(expr)}) = $structtype()
         else
-            throw(ArgumentError("Macro constructors can only be used with a struct definition or a Type"))
+            throw(ArgumentError("StructType macros can only be used with a struct definition or a Type"))
         end
     end)
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,0 +1,56 @@
+for struct_type in (:Struct, :Mutable, :CustomStruct, :OrderedStruct, :AbstractType, :DictType, :ArrayType, :StringType, :NumberType, :BoolType, :NullType)
+    @eval begin
+        @doc """
+            @$($struct_type)(expr::Expr)
+            @$($struct_type)(expr::Symbol)
+        
+        If `expr` is a struct definition, sets the `StructType` of the defined struct to
+        $($struct_type)(). If `expr` is the name of a `Type`, sets the `StructType` of that
+        type to $($struct_type)().
+
+        # Examples
+        ```julia
+        @$($struct_type) MyStruct
+        ```
+        is equivalent to
+        ```julia
+        StructTypes.StructType(::Type{MyStruct}) = StructType.Struct()
+        ```
+        and 
+        ```julia
+        @$($struct_type) struct MyStruct
+            val::Int
+        end
+        ```
+        is equivalent to
+        ```julia
+        struct MyStruct
+            val::Int
+        end
+        StructTypes.StructType(::Type{MyStruct}) = StructType.Struct()
+        ```
+        """ macro $struct_type(expr)
+            return macro_constructor(expr, $struct_type)
+        end
+    end
+end
+
+function macro_constructor(expr::Expr, structtype)
+    if expr.head == :struct
+        return esc(quote
+            $expr
+            StructTypes.StructType(::Type{$(expr.args[2])}) = $structtype()
+        end)
+    else
+        return :(throw(ArgumentError("Macro constructors can only be used with a struct definition or a Type")))
+    end
+end
+function macro_constructor(expr::Symbol, structtype)
+    return esc(quote
+        if $(expr) isa Type
+            StructTypes.StructType(::Type{$(expr)}) = $structtype()
+        else
+            throw(ArgumentError("Macro constructors can only be used with a struct definition or a Type"))
+        end
+    end)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -562,3 +562,32 @@ StructTypes.StructType(::Type{C2}) = StructTypes.Mutable()
         end
     end
 end
+
+@testset "Macros" begin
+    struct MyStruct1
+        val::Int
+    end
+    StructTypes.@Struct MyStruct1
+    @test StructTypes.StructType(MyStruct1) isa StructTypes.Struct
+
+    StructTypes.@NullType struct MyStruct2
+        val::Int
+    end
+    @test StructTypes.StructType(MyStruct2) isa StructTypes.NullType
+
+    StructTypes.@Mutable mutable struct MyStruct3
+        val::Int
+    end
+    @test StructTypes.StructType(MyStruct3) isa StructTypes.Mutable
+
+    # Test an expression that is not a struct def
+    expr = StructTypes.macro_constructor(Expr(:a), StructTypes.Struct)
+    @test_throws ArgumentError eval(expr)
+
+    # Test a symbol that is not a type
+    expr = StructTypes.macro_constructor(:var, StructTypes.Struct)
+    eval(quote
+        var = 1
+    end)
+    @test_throws ArgumentError eval(expr.args[1]) # Extract body from within escape
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -563,21 +563,21 @@ StructTypes.StructType(::Type{C2}) = StructTypes.Mutable()
     end
 end
 
+struct MyStruct1
+    val::Int
+end
+StructTypes.@Struct MyStruct1
+StructTypes.@NullType struct MyStruct2
+    val::Int
+end
+
+StructTypes.@Mutable mutable struct MyStruct3
+    val::Int
+end
+
 @testset "Macros" begin
-    struct MyStruct1
-        val::Int
-    end
-    StructTypes.@Struct MyStruct1
     @test StructTypes.StructType(MyStruct1) isa StructTypes.Struct
-
-    StructTypes.@NullType struct MyStruct2
-        val::Int
-    end
     @test StructTypes.StructType(MyStruct2) isa StructTypes.NullType
-
-    StructTypes.@Mutable mutable struct MyStruct3
-        val::Int
-    end
     @test StructTypes.StructType(MyStruct3) isa StructTypes.Mutable
 
     # Test an expression that is not a struct def


### PR DESCRIPTION
Adds macros to define StructTypes, see #64 

Example use:

```Julia
help?> StructTypes.@Struct
  @StructTypes.Struct(expr::Expr)
  @StructTypes.Struct(expr::Symbol)

  If expr is a struct definition, sets the StructType of the defined struct to StructTypes.Struct(). If expr is the name of a Type,
  sets the StructType of that type to StructTypes.Struct().

  Examples
  ≡≡≡≡≡≡≡≡≡≡

  @StructTypes.Struct MyStruct

  is equivalent to

  StructTypes.StructType(::Type{MyStruct}) = StructType.Struct()

  and

  @StructTypes.Struct struct MyStruct
      val::Int
  end

  is equivalent to

  struct MyStruct
      val::Int
  end
  StructTypes.StructType(::Type{MyStruct}) = StructType.Struct()
```

Ideally they would be exported as well, to minimise how much typing was required.

If this seems something we would want I'll add tests and docs.