### PR TITLE
Handle all types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StructTypes"
 uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 authors = ["Jacob Quinn"]
-version = "1.8.1"
+version = "1.9.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -107,13 +107,7 @@ abstract type Struct <: DataType end
 
 
 # Check for structs we can't use multiple dispatch for
-function StructType(::Type{T}) where {T}
-    if Base.issingletontype(T)
-        SingletonType()
-    else
-        Struct()
-    end
-end
+StructType(::Type{T}) where {T} = Base.issingletontype(T) ? SingletonType() : Struct()
 
 struct UnorderedStruct <: Struct end
 struct OrderedStruct <: Struct end

--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -9,11 +9,11 @@ StructType(x::T) where {T} = StructType(T)
 
 "Default `StructTypes.StructType` for types that don't have a `StructType` defined; this ensures objects must have an explicit `StructType` to avoid unanticipated issues"
 struct NoStructType <: StructType end
-struct SingletonStructType <: StructType end
+struct SingletonType <: StructType end
 
 function StructType(::Type{T}) where {T}
     if Base.issingletontype(T)
-        SingletonStructType()
+        SingletonType()
     else
         NoStructType()
     end

--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -11,6 +11,9 @@ StructType(x::T) where {T} = StructType(T)
 struct NoStructType <: StructType end
 struct SingletonType <: StructType end
 
+StructType(::Type{T}) where {T<:Exception} = NoStructType()
+StructType(::Type{T}) where {T<:Function} = NoStructType()
+
 """
     StructTypes.StructType(::Type{T}) = StructTypes.CustomStruct()
 
@@ -103,13 +106,14 @@ StructTypes.StructType(::Type{CoolType}) = StructTypes.Struct()
 abstract type Struct <: DataType end
 
 
+# Check for structs we can't use multiple dispatch for
 function StructType(::Type{T}) where {T}
-    if Base.issingletontype(T)
+    if T <: Core.Function
+        NoStructType()
+    elseif Base.issingletontype(T)
         SingletonType()
     elseif Base.isabstracttype(T)
         AbstractType()
-    elseif Base.isstructtype(T)
-        Struct()
     else
         NoStructType()
     end
@@ -421,6 +425,7 @@ StructType(::Type{T}) where {T <: Dates.TimeType} = StringType()
 StructType(::Type{VersionNumber}) = StringType()
 StructType(::Type{Base.Cstring}) = StringType()
 StructType(::Type{Base.Cwstring}) = StringType()
+StructType(::Type{Base.Regex}) = StringType()
 
 function construct(::Type{Char}, str::String; kw...)
     if length(str) == 1

--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -115,7 +115,7 @@ function StructType(::Type{T}) where {T}
     elseif Base.isabstracttype(T)
         AbstractType()
     else
-        NoStructType()
+        Struct()
     end
 end
 
@@ -127,7 +127,6 @@ Struct() = UnorderedStruct()
 StructType(u::Union) = Struct()
 StructType(::Type{Any}) = Struct()
 StructType(::Type{<:NamedTuple}) = Struct()
-StructType(::Type{DataType}) = Struct()
 
 """
     StructTypes.StructType(::Type{T}) = StructTypes.Mutable()

--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -11,8 +11,8 @@ StructType(x::T) where {T} = StructType(T)
 struct NoStructType <: StructType end
 struct SingletonType <: StructType end
 
-StructType(::Type{T}) where {T<:Exception} = NoStructType()
-StructType(::Type{T}) where {T<:Function} = NoStructType()
+StructType(::Type{<:Function}) = NoStructType()
+
 
 """
     StructTypes.StructType(::Type{T}) = StructTypes.CustomStruct()
@@ -108,12 +108,8 @@ abstract type Struct <: DataType end
 
 # Check for structs we can't use multiple dispatch for
 function StructType(::Type{T}) where {T}
-    if T <: Core.Function
-        NoStructType()
-    elseif Base.issingletontype(T)
+    if Base.issingletontype(T)
         SingletonType()
-    elseif Base.isabstracttype(T)
-        AbstractType()
     else
         Struct()
     end
@@ -476,8 +472,7 @@ Similarly for serializing, `Float64(x::T)` will first be called before serializi
 """
 struct NumberType <: InterfaceType end
 
-StructType(::Type{<:Real}) = NumberType()
-StructType(::Type{<:Complex}) = NumberType()
+StructType(::Type{<:Number}) = NumberType()
 numbertype(::Type{T}) where {T <: Real} = T
 numbertype(x) = Float64
 

--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -11,14 +11,6 @@ StructType(x::T) where {T} = StructType(T)
 struct NoStructType <: StructType end
 struct SingletonType <: StructType end
 
-function StructType(::Type{T}) where {T}
-    if Base.issingletontype(T)
-        SingletonType()
-    else
-        NoStructType()
-    end
-end
-
 """
     StructTypes.StructType(::Type{T}) = StructTypes.CustomStruct()
 
@@ -109,6 +101,16 @@ StructTypes.StructType(::Type{CoolType}) = StructTypes.Struct()
 ```
 """
 abstract type Struct <: DataType end
+
+
+function StructType(::Type{T}) where {T}
+    if Base.issingletontype(T)
+        SingletonType()
+    else
+        "Default `StructTypes.StructType` to a plain Struct()"
+        Struct()
+    end
+end
 
 struct UnorderedStruct <: Struct end
 struct OrderedStruct <: Struct end

--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -106,6 +106,10 @@ abstract type Struct <: DataType end
 function StructType(::Type{T}) where {T}
     if Base.issingletontype(T)
         SingletonType()
+    elseif Base.isabstracttype(T)
+        AbstractType()
+    elseif Base.isstructtype(T)
+        Struct()
     else
         NoStructType()
     end

--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -9,8 +9,15 @@ StructType(x::T) where {T} = StructType(T)
 
 "Default `StructTypes.StructType` for types that don't have a `StructType` defined; this ensures objects must have an explicit `StructType` to avoid unanticipated issues"
 struct NoStructType <: StructType end
+struct SingletonStructType <: StructType end
 
-StructType(::Type{T}) where {T} = NoStructType()
+function StructType(::Type{T}) where {T}
+    if Base.issingletontype(T)
+        SingletonStructType()
+    else
+        NoStructType()
+    end
+end
 
 """
     StructTypes.StructType(::Type{T}) = StructTypes.CustomStruct()

--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -107,8 +107,7 @@ function StructType(::Type{T}) where {T}
     if Base.issingletontype(T)
         SingletonType()
     else
-        "Default `StructTypes.StructType` to a plain Struct()"
-        Struct()
+        NoStructType()
     end
 end
 
@@ -120,6 +119,7 @@ Struct() = UnorderedStruct()
 StructType(u::Union) = Struct()
 StructType(::Type{Any}) = Struct()
 StructType(::Type{<:NamedTuple}) = Struct()
+StructType(::Type{DataType}) = Struct()
 
 """
     StructTypes.StructType(::Type{T}) = StructTypes.Mutable()
@@ -415,6 +415,8 @@ StructType(::Type{<:AbstractChar}) = StringType()
 StructType(::Type{UUID}) = StringType()
 StructType(::Type{T}) where {T <: Dates.TimeType} = StringType()
 StructType(::Type{VersionNumber}) = StringType()
+StructType(::Type{Base.Cstring}) = StringType()
+StructType(::Type{Base.Cwstring}) = StringType()
 
 function construct(::Type{Char}, str::String; kw...)
     if length(str) == 1
@@ -467,6 +469,7 @@ Similarly for serializing, `Float64(x::T)` will first be called before serializi
 struct NumberType <: InterfaceType end
 
 StructType(::Type{<:Real}) = NumberType()
+StructType(::Type{<:Complex}) = NumberType()
 numbertype(::Type{T}) where {T <: Real} = T
 numbertype(x) = Float64
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ end
 @test StructTypes.StructType(Any) == StructTypes.Struct()
 @test StructTypes.StructType(A) == StructTypes.NoStructType()
 @test StructTypes.StructType(A(1)) == StructTypes.NoStructType()
+@test StructTypes.StructType(EmptyStruct) == StructTypes.SingletonStructType()
 
 @test StructTypes.names(A) == ()
 @test StructTypes.names(A(1)) == ()
@@ -45,6 +46,7 @@ end
 @test StructTypes.isempty(nothing)
 @test !StructTypes.isempty(A(1))
 @test !StructTypes.isempty(A(1), 1)
+@test StructTypes.isempty(EmptyStruct)
 
 @test StructTypes.keywordargs(A) == NamedTuple()
 @test StructTypes.keywordargs(A(1)) == NamedTuple()
@@ -260,8 +262,6 @@ mutable struct DateStruct
 end
 DateStruct() = DateStruct(Date(0), DateTime(0), Time(0))
 Base.:(==)(a::DateStruct, b::DateStruct) = a.date == b.date && a.datetime == b.datetime && a.time == b.time
-
-struct EmptyStruct end
 
 @testset "convenience functions" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,31 +25,16 @@ builtin_type_mapping = Dict(
         Core.IO,
         Core.Number, 
         Base.AbstractDisplay,
-        Base.IndexStyle,
         Base.VERSION <= v"1.2" ? Union{} : Union{
             Base.AbstractMatch,
             Base.AbstractPattern,
         } 
     },
     StructTypes.UnorderedStruct() => Union{
-        Core.Any, # Seems to be too open
-    },
-    StructTypes.StringType() => Union{
-        Core.AbstractChar,
-        Core.AbstractString,
-        Core.Symbol,
-        Base.Cstring,
-        Base.Cwstring,
-        Base.Regex,
-        Base.VersionNumber,
-    },
-    StructTypes.NumberType() => Union{
-        Core.Number, # Should all of `Number` and its subtypes be Numbers by default?
-    },
-    StructTypes.NoStructType() => Union{
+        Core.Any, # Might be too open
+        Core.DataType,
         Core.Exception,
         Core.Expr,
-        Core.DataType,
         Core.GlobalRef,
         Core.IO,
         Core.LineNumberNode,
@@ -65,16 +50,34 @@ builtin_type_mapping = Dict(
         Base.AbstractDisplay,
         Base.ExponentialBackOff,
         Base.Function,
+        Base.IndexStyle,
         Base.RawFD,
-        Base.Timer,Base.VERSION <= v"1.2" ? Union{
+        Base.Timer,
+        Base.VERSION <= v"1.2" ? Union{
             Base.Condition,
             Base.ReentrantLock,
             Base.RegexMatch,
         } : Union{
             Base.AbstractLock,
             Base.AbstractMatch,
+            Base.AbstractPattern,
             Base.GenericCondition,
         },
+    },
+    StructTypes.StringType() => Union{
+        Core.AbstractChar,
+        Core.AbstractString,
+        Core.Symbol,
+        Base.Cstring,
+        Base.Cwstring,
+        Base.Regex,
+        Base.VersionNumber,
+    },
+    StructTypes.NumberType() => Union{
+        Core.Number, # Should all of `Number` and its subtypes be Numbers by default?
+    },
+    StructTypes.NoStructType() => Union{
+        Core.Function,
     },
     StructTypes.BoolType() => Union{
         Core.Bool
@@ -84,6 +87,7 @@ builtin_type_mapping = Dict(
         Base.Missing,
     },
     StructTypes.SingletonType() => Union{
+        Core.Exception,
         Core.UndefInitializer,
         Base.IndexStyle,
     },
@@ -278,7 +282,7 @@ end
     # See https://docs.julialang.org/en/v1/manual/types/ for kinds of types
 
     # Abstract Type
-    @test StructTypes.StructType(Abstract) == StructTypes.AbstractType()
+    @test StructTypes.StructType(Abstract) == StructTypes.UnorderedStruct()
 
     # Primitive Type
     @test StructTypes.StructType(Primitive) == StructTypes.NumberType()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,8 +21,8 @@ end
 
 @test StructTypes.StructType(Union{Int, Missing}) == StructTypes.Struct()
 @test StructTypes.StructType(Any) == StructTypes.Struct()
-@test StructTypes.StructType(A) == StructTypes.NoStructType()
-@test StructTypes.StructType(A(1)) == StructTypes.NoStructType()
+@test StructTypes.StructType(A) == StructTypes.Struct()
+@test StructTypes.StructType(A(1)) == StructTypes.Struct()
 @test StructTypes.StructType(EmptyStruct) == StructTypes.SingletonType()
 
 @test StructTypes.names(A) == ()
@@ -192,6 +192,49 @@ end
             @test cond
         end
     end
+
+end
+
+# Ensure all types a user can define have proper struct types
+@testset "User defined types" begin
+    # See https://docs.julialang.org/en/v1/manual/types/ for kinds of types
+
+    # Abstract Type
+    abstract type Abstract end
+    @test StructTypes.StructType(Abstract) == StructTypes.AbstractType()
+
+    # Primitive Type
+    primitive type Primitive <: Unsigned 8 end
+    @test StructTypes.StructType(Primitive) == StructTypes.NumberType()
+
+    # Composite Type
+    struct Composite
+        foo
+        bar
+    end
+    @test StructTypes.StructType(Composite) == StructTypes.UnorderedStruct()
+
+    # Mutable Composite Type
+    mutable struct MutableComposite
+        foo
+        bar
+    end
+    @test StructTypes.StructType(MutableComposite) == StructTypes.UnorderedStruct()
+
+    # Type Unions
+    TypeUnion = Union{Composite, MutableComposite}
+    @test StructTypes.StructType(TypeUnion) == StructTypes.UnorderedStruct()
+
+    # Parametric Types
+    struct Parametric{T1, T2}
+        foo::T1
+        bar::T2
+    end
+    @test StructTypes.StructType(Parametric) == StructTypes.UnorderedStruct()
+
+    # Singleton Types
+    struct Singleton end
+    @test StructTypes.StructType(Singleton) == StructTypes.SingletonType()
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,8 +127,8 @@ struct Singleton end
 
 @test StructTypes.StructType(Union{Int, Missing}) == StructTypes.Struct()
 @test StructTypes.StructType(Any) == StructTypes.Struct()
-@test StructTypes.StructType(A) == StructTypes.NoStructType()
-@test StructTypes.StructType(A(1)) == StructTypes.NoStructType()
+@test StructTypes.StructType(A) == StructTypes.UnorderedStruct()
+@test StructTypes.StructType(A(1)) == StructTypes.UnorderedStruct()
 @test StructTypes.StructType(EmptyStruct) == StructTypes.SingletonType()
 
 @test StructTypes.names(A) == ()
@@ -284,17 +284,17 @@ end
     @test StructTypes.StructType(Primitive) == StructTypes.NumberType()
 
     # Composite Type
-    @test StructTypes.StructType(Composite) == StructTypes.NoStructType() # TODO: Should this be UnorderedStruct?
+    @test StructTypes.StructType(Composite) == StructTypes.UnorderedStruct() # TODO: Should this be UnorderedStruct?
 
     # Mutable Composite Type
-    @test StructTypes.StructType(MutableComposite) == StructTypes.NoStructType() # TODO: Should this be UnorderedStruct?
+    @test StructTypes.StructType(MutableComposite) == StructTypes.UnorderedStruct() # TODO: Should this be UnorderedStruct?
 
     # Type Unions
     TypeUnion = Union{Composite, MutableComposite}
     @test StructTypes.StructType(TypeUnion) == StructTypes.UnorderedStruct()
 
     # Parametric Types
-    @test StructTypes.StructType(Parametric) == StructTypes.NoStructType() # TODO: Should be UnorderedStruct?
+    @test StructTypes.StructType(Parametric) == StructTypes.UnorderedStruct() # TODO: Should be UnorderedStruct?
 
     # Singleton Types
     @test StructTypes.StructType(Singleton) == StructTypes.SingletonType()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ end
 @test StructTypes.isempty(nothing)
 @test !StructTypes.isempty(A(1))
 @test !StructTypes.isempty(A(1), 1)
-@test StructTypes.isempty(EmptyStruct)
+@test !StructTypes.isempty(EmptyStruct)
 
 @test StructTypes.keywordargs(A) == NamedTuple()
 @test StructTypes.keywordargs(A(1)) == NamedTuple()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ end
 @test StructTypes.StructType(Any) == StructTypes.Struct()
 @test StructTypes.StructType(A) == StructTypes.NoStructType()
 @test StructTypes.StructType(A(1)) == StructTypes.NoStructType()
-@test StructTypes.StructType(EmptyStruct) == StructTypes.SingletonStructType()
+@test StructTypes.StructType(EmptyStruct) == StructTypes.SingletonType()
 
 @test StructTypes.names(A) == ()
 @test StructTypes.names(A(1)) == ()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -256,7 +256,7 @@ end
 @test counter == 0
 end
 
-# Make sure all builtin types have struct types, except where we don't want them to
+# Make sure all builtin types have struct types
 @testset "Built in Julia types" begin
 
     # tuples containing (module, property)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ struct OmitEmp
 end
 
 # Built in types and what they should parse to
-# This should cover all subtypes TODO
+# This should cover all subtypes
 # Abstract types appear twice because they themselves are abstract but their subclasses are not
 builtin_type_mapping = Dict(
     StructTypes.AbstractType() => Union{
@@ -284,17 +284,17 @@ end
     @test StructTypes.StructType(Primitive) == StructTypes.NumberType()
 
     # Composite Type
-    @test StructTypes.StructType(Composite) == StructTypes.UnorderedStruct() # TODO: Should this be UnorderedStruct?
+    @test StructTypes.StructType(Composite) == StructTypes.UnorderedStruct()
 
     # Mutable Composite Type
-    @test StructTypes.StructType(MutableComposite) == StructTypes.UnorderedStruct() # TODO: Should this be UnorderedStruct?
+    @test StructTypes.StructType(MutableComposite) == StructTypes.UnorderedStruct()
 
     # Type Unions
     TypeUnion = Union{Composite, MutableComposite}
     @test StructTypes.StructType(TypeUnion) == StructTypes.UnorderedStruct()
 
     # Parametric Types
-    @test StructTypes.StructType(Parametric) == StructTypes.UnorderedStruct() # TODO: Should be UnorderedStruct?
+    @test StructTypes.StructType(Parametric) == StructTypes.UnorderedStruct()
 
     # Singleton Types
     @test StructTypes.StructType(Singleton) == StructTypes.SingletonType()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,18 @@ end
 
 @testset "StructTypes" begin
 
+# Need to test all possible types.  See https://docs.julialang.org/en/v1/manual/types/
+
+# Abstract -> Not necessary, instances aren't abstract
+# Primitive -> Every primitive type is already handled, and new primitives inherit from that
+# Composite
+# Mutable Composite
+# Type Unions
+# Parametric types
+# UnionAll
+# Singleton
+# Value types
+
 @test StructTypes.StructType(Union{Int, Missing}) == StructTypes.Struct()
 @test StructTypes.StructType(Any) == StructTypes.Struct()
 @test StructTypes.StructType(A) == StructTypes.NoStructType()


### PR DESCRIPTION
This adds a test for all types built in to `Core` and `Base`, as well as unit tests for all the ways a user can define a type

I think this MR is a can of worms and likely won't be what goes in, but it does show some missing types from Core and Base, as well as tests to keep up with newer Julia versions' changes to Core and Base