### PR TITLE
Add optional setting of defaults for Structs

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -862,6 +862,9 @@ mappings will be applied, and the function will be passed the Julia field name.
             end
         end
     )
+    if !f_applied && haskey(defaults(T), nm)
+        setfield!(x, nm, defaults(T)[nm])
+    end
     return f_applied
 end
 
@@ -1014,6 +1017,10 @@ constructfrom!(::Mutable, x::T, obj::S) where {T, S} =
     constructfrom!(Mutable(), x::T, StructType(S), obj)
 
 function constructfrom!(::Mutable, x::T, ::DictType, obj) where {T}
+    if !isempty(defaults(T))
+        # must be in this order to allow overriding of defaults
+        obj = merge(defaults(T), obj)
+    end
     for (k, v) in keyvaluepairs(obj)
         applyfield!(Closure(v), x, k)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -591,3 +591,14 @@ end
     end)
     @test_throws ArgumentError eval(expr.args[1]) # Extract body from within escape
 end
+
+struct Defaultable
+    a::String
+    b::String
+end
+StructTypes.StructType(::Type{Defaultable}) = StructTypes.Struct()
+StructTypes.defaults(::Type{Defaultable}) = (b="b",)
+@testset "Defaultable" begin
+    @test StructTypes.constructfrom(Defaultable, Dict(:a=>"a")) == Defaultable("a", "b")
+    @test StructTypes.constructfrom(Defaultable, (a="a", b="c")) == Defaultable("a", "c")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -499,6 +499,7 @@ mutable struct C2
 end
 
 StructTypes.StructType(::Type{C2}) = StructTypes.Mutable()
+StructTypes.defaults(::Type{C2}) = (b=2.5,)
 
 @testset "makeobj" begin
     @testset "makeobj" begin
@@ -559,6 +560,14 @@ StructTypes.StructType(::Type{C2}) = StructTypes.Mutable()
             @test StructTypes.constructfrom(Tuple{Int64, Float64, String}, Union{Int64, Float64, String}[Int64(1), 2.0, "three"]) == (1, 2.0, "three")
             @test StructTypes.constructfrom(NamedTuple{(:a, :b, :c), Tuple{Int64, Float64, String}}, input) == (a=1, b=2.0, c="three")
             @test StructTypes.constructfrom(NamedTuple{(:a, :b, :c), Tuple{Int64, Float64, String}}, x) == (a=1, b=2.0, c="three")
+        end
+        @testset "constructfrom with defaults" begin
+            input = Dict(:a => 1, :c => "three")
+            output = StructTypes.constructfrom(C2, input)
+            @test typeof(output) === C2
+            @test output.a == 1
+            @test output.b == 2.5
+            @test output.c == "three"
         end
     end
 end


### PR DESCRIPTION
Previously requested by @Roger-luo and others. `merge(::NamedTuple, ::Dict)` works so this should be safe even if the input to `constructfrom` is a `Dict`. Happy to make modifications/expand to `UnorderedStruct` and `CustomStruct` if anyone would like.