### PR TITLE
Also allow using defaults from `JSON3.read`

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -878,6 +878,8 @@ end
     Base.@nexprs 32 i -> begin
         if isassigned(values, i)
             x_i = values[i]::fieldtype(T, i)
+        elseif !isempty(defaults(T))
+            x_i = get(defaults(T), fieldname(T, i), nothing)
         else
             x_i = nothing
         end


### PR DESCRIPTION
That method bypasses `constructfrom`, so we need this as well to directly read in instances with missing fields that have defaults.