### PR TITLE
Support constructing Numbers from Strings

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -320,6 +320,7 @@ The default definition is `StructTypes.construct(T, args...; kw...) = T(args...;
 """
 construct(T, args...; kw...) = T(args...; kw...)
 construct(::Type{T}, x::T; kw...) where {T} = x
+construct(::Type{T}, arg::String; kw...) where {T<:Number} = tryparse(T, arg)
 
 """
     StructTypes.StructType(::Type{T}) = StructTypes.DictType()


### PR DESCRIPTION
Similar to `constructfrom`, `Int64("1")` (for example) will error.