### PR TITLE
Remove keyword arguments before calling UUID constructor

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -457,6 +457,8 @@ construct(::Type{T}, ptr::Ptr{UInt8}, len::Int; kw...) where {T} = construct(T, 
 construct(::Type{Symbol}, ptr::Ptr{UInt8}, len::Int; kw...) = _symbol(ptr, len)
 construct(::Type{T}, str::String; dateformat::Dates.DateFormat=Dates.default_format(T), kw...) where {T <: Dates.TimeType} = T(str, dateformat)
 
+construct(::Type{UUID}, arg; kw...) = UUID(arg)
+
 """
     StructTypes.StructType(::Type{T}) = StructTypes.NumberType()
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,6 +207,7 @@ x = "apple"
 @test StructTypes.construct(Symbol, pointer(x), 5) == :apple
 x = "499beb72-22ea-11ea-3366-55749430b981"
 @test StructTypes.construct(UUID, pointer(x), 36) == UUID(x)
+@test StructTypes.construct(UUID, pointer(x), 36; dateformat=dateformat"mm-dd-yyyy") == UUID(x)
 @test StructTypes.construct(Date, "11-30-2019"; dateformat=dateformat"mm-dd-yyyy") == Date(2019, 11, 30)
 
 @test StructTypes.StructType(UInt8) == StructTypes.NumberType()


### PR DESCRIPTION
JSON3 passes keyword arguemnts to all constructors, need to remove them here since UUID doesn't take any.