### PR TITLE
Add macro for subtypes lowering with additional `subtypekey` field

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StructTypes"
 uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 authors = ["Jacob Quinn"]
-version = "1.10.2"
+version = "1.11.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StructTypes"
 uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 authors = ["Jacob Quinn"]
-version = "1.10.1"
+version = "1.10.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -71,7 +71,7 @@ struct Car <: Vehicle
 end
 StructTypes.subtypekey(::Type{Vehicle}) = :type
 StructTypes.subtypes(::Type{Vehicle}) = (car=Car, truck=Truck)
-@register_struct_subtype Vehicle Car
+StructTypes.@register_struct_subtype Vehicle Car
 ```
 """
 macro register_struct_subtype(abstract_type, struct_subtype)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -824,3 +824,35 @@ StructTypes.defaults(::Type{Defaultable}) = (b="b",)
     @test StructTypes.constructfrom(Defaultable, Dict(:a=>"a")) == Defaultable("a", "b")
     @test StructTypes.constructfrom(Defaultable, (a="a", b="c")) == Defaultable("a", "c")
 end
+
+# CustomStruct subtypes
+abstract type Vehicle2 end
+
+struct Car2 <: Vehicle2
+    make::String
+    model::String
+    seatingCapacity::Int
+    topSpeed::Float64
+end
+
+struct Truck2 <: Vehicle2
+    # type::String no need of this
+    make::String
+    model::String
+    payloadCapacity::Float64
+end
+
+StructTypes.StructType(::Type{Vehicle2}) = StructTypes.AbstractType()
+StructTypes.subtypekey(::Type{Vehicle2}) = :type
+StructTypes.subtypes(::Type{Vehicle2}) = (car=Car2, truck=Truck2)
+@register_struct_subtype Vehicle2 Car2
+@register_struct_subtype Vehicle2 Truck2
+
+@testset "register_struct_subtype" begin
+    nt = (; :type => :car, :make => "Mercedes-Benz", :model => "S500", :seatingCapacity => 5, :topSpeed => 250.1)
+    car = Car2(nt)
+    @test StructTypes.lower(car) === nt
+    @test StructTypes.lowertype(Car2) === typeof(nt)
+    @test typeof(car) == Car2
+    @test car.make == "Mercedes-Benz"
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -845,8 +845,8 @@ end
 StructTypes.StructType(::Type{Vehicle2}) = StructTypes.AbstractType()
 StructTypes.subtypekey(::Type{Vehicle2}) = :type
 StructTypes.subtypes(::Type{Vehicle2}) = (car=Car2, truck=Truck2)
-@register_struct_subtype Vehicle2 Car2
-@register_struct_subtype Vehicle2 Truck2
+StructTypes.@register_struct_subtype Vehicle2 Car2
+StructTypes.@register_struct_subtype Vehicle2 Truck2
 
 @testset "register_struct_subtype" begin
     nt = (; :type => :car, :make => "Mercedes-Benz", :model => "S500", :seatingCapacity => 5, :topSpeed => 250.1)


### PR DESCRIPTION
Not sure if this API covers all cases, maybe some other key types should be added (now its only Symbol).

closes #93 and https://github.com/quinnj/JSON3.jl/issues/12