### PR TITLE
Fix #92. Unapplied defaults should be checked in `applyfield!`.

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -841,6 +841,9 @@ mappings will be applied, and the function will be passed the Julia field name.
             end
         end
     )
+    if !f_applied && haskey(defaults(T), nm)
+        setfield!(x, nm, defaults(T)[nm])
+    end
     return f_applied
 end
 
@@ -890,9 +893,6 @@ mappings will be applied, and the function will be passed the Julia field name.
             end
         end
     )
-    if !f_applied && haskey(defaults(T), nm)
-        setfield!(x, nm, defaults(T)[nm])
-    end
     return f_applied
 end
 


### PR DESCRIPTION
I met a problem when trying to deserialize something with `JSON3.jl` with a default value that isn't in the type fields, and found these lines were defined under the wrong function. It fixes #92 because `x` is only defined in `applyfield!` but not in `applyfield`.