### PR TITLE
fix struct type for number

### DIFF
--- a/src/StructTypes.jl
+++ b/src/StructTypes.jl
@@ -481,7 +481,7 @@ Similarly for serializing, `Float64(x::T)` will first be called before serializi
 """
 struct NumberType <: InterfaceType end
 
-StructType(::Type{<:Number}) = NumberType()
+StructType(::Type{<:Real}) = NumberType()
 numbertype(::Type{T}) where {T <: Real} = T
 numbertype(x) = Float64
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -856,3 +856,7 @@ StructTypes.@register_struct_subtype Vehicle2 Truck2
     @test typeof(car) == Car2
     @test car.make == "Mercedes-Benz"
 end
+
+@testset "struct type on complex" begin
+    @test StructTypes.StructType(ComplexF64) == StructTypes.Struct()
+end


### PR DESCRIPTION
Before the fix, JSON3 tries to parse a complex number to real type.
After the fix, the behavior is correct:
```julia
julia> JSON3.write(1+2im)
"{\"re\":1,\"im\":2}"
```

The JSON number type should correspond to the Julia Real number type.

Can we tag a patch version after the fix? Thanks!